### PR TITLE
Beep/flash the ACR122 when a tag is detected

### DIFF
--- a/nfc/clf/__init__.py
+++ b/nfc/clf/__init__.py
@@ -240,6 +240,11 @@ class ContactlessFrontend(object):
            this value will impair one or the other. There is no free
            beer.
 
+        'beep-on-connect': boolean
+            If the device supports beeping or flashing an LED, automatically
+            perform this functionality when a tag is successfully detected.
+            Defaults to True.
+
         .. sourcecode:: python
 
            import nfc
@@ -522,7 +527,8 @@ class ContactlessFrontend(object):
             rdwr_options.setdefault('on-release', lambda tag: True)
             rdwr_options.setdefault('iterations', 5)
             rdwr_options.setdefault('interval', 0.5)
-            
+            rdwr_options.setdefault('beep-on-connect', True)
+
             targets = [RemoteTarget(brty) for brty in rdwr_options['targets']]
             targets = rdwr_options['on-startup'](targets)
             if targets and all([isinstance(o, RemoteTarget) for o in targets]):
@@ -586,11 +592,15 @@ class ContactlessFrontend(object):
                 tag = nfc.tag.activate(self, target)
                 if tag is not None:
                     log.debug("connected to {0}".format(tag))
+                    if options['beep-on-connect']:
+                        self.device.turn_on_led_and_buzzer()
                     if options['on-connect'](tag):
                         while not terminate() and tag.is_present:
                             time.sleep(0.1)
+                        self.device.turn_off_led_and_buzzer()
                         return options['on-release'](tag)
                     else:
+                        self.device.turn_off_led_and_buzzer()
                         return tag
         
     def _llcp_connect(self, options, terminate):

--- a/nfc/clf/acr122.py
+++ b/nfc/clf/acr122.py
@@ -185,12 +185,12 @@ class Chipset(pn532.Chipset):
         self.ccid_xfr_block(bytearray.fromhex("FF00400E0400000000"))
 
     def set_buzzer_and_led_to_active(self, duration_in_ms=300):
-        """Turn on buzzer and set LED to red only. The timeout here must exceed the total buzzer/flash duration defined
-        in bytes 5-8. """
+        """Turn on buzzer and set LED to red only. The timeout here must exceed
+         the total buzzer/flash duration defined in bytes 5-8. """
         duration_in_tenths_of_second = min(duration_in_ms / 100, 255)
         timeout_in_seconds = (duration_in_tenths_of_second + 1) / 10.0
-        self.ccid_xfr_block(bytearray.fromhex("FF00400D04{:02X}000101".format(duration_in_tenths_of_second)),
-                            timeout=timeout_in_seconds)
+        data = "FF00400D04{:02X}000101".format(duration_in_tenths_of_second)
+        self.ccid_xfr_block(bytearray.fromhex(data), timeout=timeout_in_seconds)
 
     def ccid_xfr_block(self, data, timeout=0.1):
         """Encapsulate host command *data* into an PC/SC Escape command to

--- a/nfc/clf/acr122.py
+++ b/nfc/clf/acr122.py
@@ -125,6 +125,15 @@ class Device(pn532.Device):
         info = "{device} does not support listen as DEP Target"
         raise nfc.clf.UnsupportedTargetError(info.format(device=self))
 
+    def turn_on_led_and_buzzer(self):
+        """Buzz and turn red."""
+        self.chipset.set_buzzer_and_led_to_active()
+
+    def turn_off_led_and_buzzer(self):
+        """Back to green."""
+        self.chipset.set_buzzer_and_led_to_default()
+
+
 class Chipset(pn532.Chipset):
     # Maximum size of a host command frame to the contactless chip.
     host_command_frame_max_size = 254
@@ -162,14 +171,26 @@ class Chipset(pn532.Chipset):
         
         # switch red/green led off/on
         log.debug("Configure Buzzer and LED")
-        self.ccid_xfr_block(bytearray.fromhex("FF00400E0400000000"))
-        
+        self.set_buzzer_and_led_to_default()
+
         super(Chipset, self).__init__(transport, logger=log)
         
     def close(self):
         self.ccid_xfr_block(bytearray.fromhex("FF00400C0400000000"))
         self.transport.close()
         self.transport = None
+
+    def set_buzzer_and_led_to_default(self):
+        """Turn off buzzer and set LED to default (green only). """
+        self.ccid_xfr_block(bytearray.fromhex("FF00400E0400000000"))
+
+    def set_buzzer_and_led_to_active(self, duration_in_ms=300):
+        """Turn on buzzer and set LED to red only. The timeout here must exceed the total buzzer/flash duration defined
+        in bytes 5-8. """
+        duration_in_tenths_of_second = min(duration_in_ms / 100, 255)
+        timeout_in_seconds = (duration_in_tenths_of_second + 1) / 10.0
+        self.ccid_xfr_block(bytearray.fromhex("FF00400D04{:02X}000101".format(duration_in_tenths_of_second)),
+                            timeout=timeout_in_seconds)
 
     def ccid_xfr_block(self, data, timeout=0.1):
         """Encapsulate host command *data* into an PC/SC Escape command to

--- a/nfc/clf/device.py
+++ b/nfc/clf/device.py
@@ -588,7 +588,21 @@ class Device(object):
         cname = self.__class__.__module__ + '.' + self.__class__.__name__
         fname = "get_max_recv_data_size"
         raise NotImplementedError("%s.%s() must be implemented"%(cname,fname))
-    
+
+    def turn_on_led_and_buzzer(self):
+        """If a device has an LED and/or a buzzer, this method can be
+        implemented to turn those indicators to the ON state.
+
+        """
+        pass
+
+    def turn_off_led_and_buzzer(self):
+        """If a device has an LED and/or a buzzer, this method can be
+        implemented to turn those indicators to the OFF state.
+
+        """
+        pass
+
     @staticmethod
     def add_crc_a(data):
         # Calculate CRC-A for bytearray *data* and return *data*


### PR DESCRIPTION
I've added a couple methods to the abstract Device class that are intended to turn on/off an LED and buzzer if available.  The default implementation does nothing.  These methods are called by the _rdwr_connect method of the ContactlessFrontend, and can be disabled by setting the rdwr option 'beep-on-connect' to False.

The only device I have available is the ACR122, so I've implemented the on/off functionality in that particular device class.  If other devices support similar notifications, it can easily be implemented in the device's class with no further changes to ContactlessFrontend.

This is my first contribution to nfcpy, so please let me know if there are any stylistic or documentation changes that I need to make.  Thank you.