### PR TITLE
Typo fix (EACCESS -> EACCES)

### DIFF
--- a/nfc/clf/transport.py
+++ b/nfc/clf/transport.py
@@ -262,7 +262,7 @@ class USB(object):
             self.usb_dev = dev.open()
             self.usb_dev.claimInterface(0)
         except libusb.USBErrorAccess:
-            raise IOError(errno.EACCESS, os.strerror(errno.EACCESS))
+            raise IOError(errno.EACCES, os.strerror(errno.EACCES))
         except libusb.USBErrorBusy:
             raise IOError(errno.EBUSY, os.strerror(errno.EBUSY))
         except libusb.USBErrorNoDevice:


### PR DESCRIPTION
Currently, when line 265 in nfc/clf/transport.py is executed, Python says it has no attribute "EACCESS". I guess it is misspelling of EACCES.
ref: https://docs.python.org/2.7/library/errno.html