### PR TITLE
Perform the on-connect callback prior to beeping and flashing the LED…

### DIFF
--- a/src/nfc/clf/__init__.py
+++ b/src/nfc/clf/__init__.py
@@ -607,9 +607,10 @@ class ContactlessFrontend(object):
                 tag = nfc.tag.activate(self, target)
                 if tag is not None:
                     log.debug("connected to {0}".format(tag))
+                    on_connect_result = options['on-connect'](tag)
                     if options['beep-on-connect']:
                         self.device.turn_on_led_and_buzzer()
-                    if options['on-connect'](tag):
+                    if on_connect_result:
                         while not terminate() and tag.is_present:
                             time.sleep(0.1)
                         self.device.turn_off_led_and_buzzer()

--- a/src/nfc/clf/__init__.py
+++ b/src/nfc/clf/__init__.py
@@ -248,9 +248,10 @@ class ContactlessFrontend(object):
            beer.
 
         'beep-on-connect': boolean
-            If the device supports beeping or flashing an LED, automatically
-            perform this functionality when a tag is successfully detected.
-            Defaults to True.
+            If the device supports beeping or flashing an LED, 
+            automatically perform this functionality when a tag is 
+            successfully detected AND the 'on-connect' function 
+            returns a true value. Defaults to True.
 
         .. sourcecode:: python
 
@@ -607,16 +608,14 @@ class ContactlessFrontend(object):
                 tag = nfc.tag.activate(self, target)
                 if tag is not None:
                     log.debug("connected to {0}".format(tag))
-                    on_connect_result = options['on-connect'](tag)
-                    if options['beep-on-connect']:
-                        self.device.turn_on_led_and_buzzer()
-                    if on_connect_result:
+                    if options['on-connect'](tag):
+                        if options['beep-on-connect']:
+                            self.device.turn_on_led_and_buzzer()
                         while not terminate() and tag.is_present:
                             time.sleep(0.1)
                         self.device.turn_off_led_and_buzzer()
                         return options['on-release'](tag)
                     else:
-                        self.device.turn_off_led_and_buzzer()
                         return tag
 
     def _llcp_connect(self, options, terminate):


### PR DESCRIPTION
….  From a human's perspective, the beep is a notification that the tag read is complete and the tag can be removed from the reader.  Depending on what happens in the connect handler, this may not be the case.  In my example test case, I was reading two NDEF records from the tag in on-connect.  If the tag was removed from the field immediately after the beep, the NDEF records were not successfully read.  Changing this order does not guarantee that all operations in on-connect will succeed, but it does guarantee that on-connect is complete prior to telling the human that the tag has been read.