### PR TITLE
Raise TagCommandError when NDEF write fails.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Changelog for nfcpy
 ===================
 
+0.13.4 (2017-11-10)
+-------------------
+
+* Raise nfc.tag.TagCommandError when NDEF data could not be written to
+  the tag. Previously this was captured within the tag memory cache
+  for Type1Tag and Type2Tag and raised as IndexError.
+
 0.13.3 (2017-11-02)
 -------------------
 

--- a/src/nfc/__init__.py
+++ b/src/nfc/__init__.py
@@ -32,7 +32,7 @@ logging.getLogger(__name__).setLevel(logging.INFO)
 
 # METADATA ####################################################################
 
-__version__ = "0.13.3"
+__version__ = "0.13.4"
 
 __title__ = "nfcpy"
 __description__ = "Python module for Near Field Communication."

--- a/src/nfc/tag/__init__.py
+++ b/src/nfc/tag/__init__.py
@@ -182,11 +182,14 @@ class Tag(object):
             from the NDEF message data or set the message data from a
             list of records. ::
 
+                from ndef import TextRecord
                 if tag.ndef is not None:
                     for record in tag.ndef.records:
                         print(record)
-                    import ndef
-                    tag.ndef.records = [ndef.TextRecord('Hello World')]
+                    try:
+                        tag.ndef.records = [TextRecord('Hello World')]
+                    except nfc.tag.TagCommandError as err:
+                        print("NDEF write failed: " + str(err))
 
             Decoding is performed with a relaxed error handling
             strategy that ignores minor errors in the NDEF data. The

--- a/src/nfc/tag/tt2.py
+++ b/src/nfc/tag/tt2.py
@@ -153,7 +153,7 @@ class Type2Tag(Tag):
                 self._readable = bool(tag_memory[15] >> 4 == 0)
                 self._writeable = bool(tag_memory[15] & 0xF == 0)
                 return True
-            except IndexError:
+            except Type2TagCommandError:
                 log.debug("first four memory pages were unreadable")
                 return False
 
@@ -178,7 +178,7 @@ class Type2Tag(Tag):
                 try:
                     tlv = read_tlv(tag_memory, offset, skip_bytes)
                     tlv_t, tlv_l, tlv_v = tlv
-                except IndexError:
+                except Type2TagCommandError:
                     return None
                 else:
                     logmsg = "tlv type {0} length {1} at offset {2}"
@@ -652,28 +652,22 @@ class Type2TagMemoryReader(object):
 
     def _read_from_tag(self, stop):
         index = (len(self) >> 4) << 4
-        try:
-            while index < stop:
-                self._tag.sector_select(index >> 10)
-                data = self._tag.read(index >> 2)
-                self._data_from_tag[index:] = data
-                self._data_in_cache[index:] = data
-                index += 16
-        except Type2TagCommandError:
-            pass
+        while index < stop:
+            self._tag.sector_select(index >> 10)
+            data = self._tag.read(index >> 2)
+            self._data_from_tag[index:] = data
+            self._data_in_cache[index:] = data
+            index += 16
 
     def _write_to_tag(self, stop):
         index = 0
-        try:
-            while index < stop:
-                data = self._data_in_cache[index:index+4]
-                if data != self._data_from_tag[index:index+4]:
-                    self._tag.sector_select(index >> 10)
-                    self._tag.write(index >> 2, data)
-                    self._data_from_tag[index:index+4] = data
-                index += 4
-        except Type2TagCommandError:
-            pass
+        while index < stop:
+            data = self._data_in_cache[index:index+4]
+            if data != self._data_from_tag[index:index+4]:
+                self._tag.sector_select(index >> 10)
+                self._tag.write(index >> 2, data)
+                self._data_from_tag[index:index+4] = data
+            index += 4
 
     def synchronize(self):
         """Write pages that contain modified data back to tag memory."""

--- a/tests/test_tag_tt2.py
+++ b/tests/test_tag_tt2.py
@@ -819,8 +819,9 @@ class TestMemoryReader:
         ]
         tag.clf.exchange.side_effect = responses
         tag_memory = nfc.tag.tt2.Type2TagMemoryReader(tag)
-        with pytest.raises(IndexError):
+        with pytest.raises(nfc.tag.TagCommandError) as excinfo:
             tag_memory[16] = 0xfe
+        assert str(excinfo.value) == "unrecoverable timeout error"
         assert tag.clf.exchange.mock_calls == [mock.call(*_) for _ in commands]
 
     def test_write_error(self, tag):
@@ -841,5 +842,7 @@ class TestMemoryReader:
         tag.clf.exchange.side_effect = responses
         tag_memory = nfc.tag.tt2.Type2TagMemoryReader(tag)
         tag_memory[16] = 0xfe
-        tag_memory.synchronize()
+        with pytest.raises(nfc.tag.TagCommandError) as excinfo:
+            tag_memory.synchronize()
+        assert str(excinfo.value) == "unrecoverable timeout error"
         assert tag.clf.exchange.mock_calls == [mock.call(*_) for _ in commands]


### PR DESCRIPTION
Raise nfc.tag.TagCommandError when NDEF data could not be written to the tag. Previously this was captured within the tag memory cache for Type1Tag and Type2Tag and raised as IndexError.