### PR TITLE
Fix the documentation build on Read The Docs

### DIFF
--- a/src/nfc/clf/transport.py
+++ b/src/nfc/clf/transport.py
@@ -27,10 +27,11 @@ import re
 import errno
 from binascii import hexlify
 
-try:
-    import usb1 as libusb
-except ImportError:  # pragma: no cover
-    raise ImportError("missing usb1 module, try 'pip install libusb1'")
+if not os.getenv("READTHEDOCS"):  # pragma: no cover
+    try:
+        import usb1 as libusb
+    except ImportError:  # pragma: no cover
+        raise ImportError("missing usb1 module, try 'pip install libusb1'")
 
 try:
     import serial


### PR DESCRIPTION
There is no libusb installed on RTD build environment, hence the import will fail to load the libusb dynamic library when RTD imports the source code to get the embedded documentation. This can be fixed by not importing libusb when the READTHEDOCS environment variable is set.