### PR TITLE
Use pycryptodome DES3 and drop pyDes dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ CLASSIFIERS = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "License :: OSI Approved :: European Union Public Licence 1.1 (EUPL 1.1)",
 ]
-INSTALL_REQUIRES = ["libusb1", "pyserial", "ndeflib", "pydes"]
+INSTALL_REQUIRES = ["libusb1", "pyserial", "ndeflib", "pycryptodome"]
 PYTHON_REQUIRES = ">=2.6"
 
 ###############################################################################

--- a/tests/test_tag_tt3_sony.py
+++ b/tests/test_tag_tt3_sony.py
@@ -811,11 +811,11 @@ class TestFelicaLite:
         (False, "0b1268d7a4ac6932"),
         (True, "18cdd33c0fb25dd7"),
     ])
-    def test_generate_mac(self, flip_key, mac_result):
+    def test__generate_mac(self, flip_key, mac_result):
         data = bytearray(range(32))
         key = bytearray(range(16))
         iv = bytearray(range(8))
-        mac = nfc.tag.tt3_sony.FelicaLite.generate_mac(data, key, iv, flip_key)
+        mac = nfc.tag.tt3_sony.FelicaLite._generate_mac(data, key, iv, flip_key)
         assert mac == HEX(mac_result)
 
     def test_read_with_mac(self, tag):


### PR DESCRIPTION
Use pycryptodome DES3 and drop pyDes dep

I'm having trouble installing `nfcpy` due to the `pyDes` transitive dependency. We can probably fix the dependency issue, but I'm wondering if it is worth moving to [pycryptodome](https://github.com/Legrandin/pycryptodome) which appears to be better supported in general. 