### PR TITLE
Restores RF_Configuration for NFC B to the default PN-532 settings

### DIFF
--- a/src/nfc/clf/pn532.py
+++ b/src/nfc/clf/pn532.py
@@ -207,7 +207,7 @@ class Device(pn53x.Device):
         self.chipset.rf_configuration(0x0B, data)
 
         self.log.debug("write analog settings for Type B 106 kbps")
-        data = bytearray.fromhex("FF 04 85")
+        data = bytearray.fromhex("FF 17 85")
         self.chipset.rf_configuration(0x0C, data)
 
         self.log.debug("write analog settings for 14443-4 212/424/848 kbps")


### PR DESCRIPTION
Some [PN-532](https://shop.mtoolstec.com/product/mtools-all-in-one-pn532?attribute_pa_device-type=pn532) readers are not reading 106B tags with nfcpy. This PR restores the CIU_ModGsP value for Type B analog settings to 0x17 from 0x04, which is the default value for this config as seen in page 105 of [the user manual](https://www.nxp.com/docs/en/user-guide/141520.pdf). A local test with PN-532 hardware verifies that this works. 

As can be seen in lines 201-207, the analog settings for Type A and Type F (which both work) match the default settings as described in page 104 and 105 of the [manual](https://www.nxp.com/docs/en/user-guide/141520.pdf). Thus, this change proposes the same action for Type B.
This issue has been seen before as well: https://github.com/nfcpy/nfcpy/issues/187 