### PR TITLE
Fix serial devices with dot character (.) in path

### DIFF
--- a/src/nfc/clf/transport.py
+++ b/src/nfc/clf/transport.py
@@ -47,7 +47,7 @@ except ImportError:  # pragma: no cover
 import logging
 log = logging.getLogger(__name__)
 
-PATH = re.compile(r'^([a-z]+)(?::|)([a-zA-Z0-9-]+|)(?::|)([a-zA-Z0-9]+|)$')
+PATH = re.compile(r'^([a-z]+)(?::|)([a-zA-Z0-9-.]+|)(?::|)([a-zA-Z0-9]+|)$')
 
 
 class TTY(object):


### PR DESCRIPTION
Serial devices with a dot (.) in the name were not working. 
For example: /dev/tty.usbserial-A5XK3RJT (on MacOS)